### PR TITLE
fix: include upgrade notes that apply for v3.28+

### DIFF
--- a/charts/tigera-operator/README.md
+++ b/charts/tigera-operator/README.md
@@ -45,6 +45,16 @@ of the chart into the `tigera-operator` namespace.
 When upgrading from a version of Calico v3.22 or lower to a version of Calico v3.23 or greater, you must complete the following steps to migrate
 ownership of the helm resources to the new chart location.
 
+## Upgrade OwnerReferences
+
+If you do not use OwnerReferences on resources in the projectcalico.org/v3 API group, you can skip this section.
+
+Starting in Calico v3.28, a change in the way UIDs are generated for projectcalico.org/v3 resources requires that you update any OwnerReferences that refer to projectcalico.org/v3 resources as an owner. After upgrade, the UID for all projectcalico.org/v3 resources will be changed, resulting in any owned resources being garbage collected by Kubernetes.
+
+1. Remove any OwnerReferences from resources in your cluster that have apiGroup: projectcalico.org/v3.
+2. Perform the upgrade normally.
+3. Add new OwnerReferences to your resources referencing the new UID.
+
 ## Upgrade from Calico versions prior to v3.23.0
 
 1. Patch existing resources so that the new chart can assume ownership.


### PR DESCRIPTION
## Description

Documentation updates. 

Artifacthub's README.md upgrade steps did not include: https://docs.tigera.io/calico/latest/operations/upgrading/kubernetes-upgrade#upgrade-ownerreferences

## Related issues/PRs
N/A

## Todos

- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note



```release-note
Update docs to include upgrade instructions for v1.28+
```

## Reminder for the reviewer

Make sure that this PR has the correct labels and milestone set.

Every PR needs one `docs-*` label.

- `docs-pr-required`: This change requires a change to the documentation that has not been completed yet.
- `docs-completed`: This change has all necessary documentation completed.
- `docs-not-required`: This change has no user-facing impact and requires no docs.

Every PR needs one `release-note-*` label.

- `release-note-required`: This PR has user-facing changes. Most PRs should have this label.
- `release-note-not-required`: This PR has no user-facing changes.

Other optional labels:

- `cherry-pick-candidate`: This PR should be cherry-picked to an earlier release. For bug fixes only.
- `needs-operator-pr`: This PR is related to install and requires a corresponding change to the operator.



